### PR TITLE
Update example in readme to use named import instead of default import

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Made with <a href="https://github.com/walaura">@walaura</a>
 ## Usage
 
 ```jsx
-import useClippy from 'use-clippy-now'
+import { useClippy } from 'use-clippy-now'
 
 function App() {
   const withClippy = useClippy('Clippy')


### PR DESCRIPTION
`useClippy` function is exported as a named export but in the readme's example it shows it being imported as if it was a default import so this pr updates readme so they match